### PR TITLE
NewRelic browser support w/ playframework

### DIFF
--- a/src/main/resources/com/gilt/sbt/newrelic/newrelic.yml.template
+++ b/src/main/resources/com/gilt/sbt/newrelic/newrelic.yml.template
@@ -241,7 +241,7 @@ common: &default_settings
     # See https://docs.newrelic.com/docs/java/real-user-monitoring-in-java#manual_instrumentation
     # for instructions to add these manually to your pages.
     # Set this attribute to false to turn off this behavior.
-    auto_instrument: true
+    auto_instrument: ${{browser_monitoring}}
 
   class_transformer:
     # This instrumentation reports the name of the user principal returned from 

--- a/src/main/scala/NewRelic.scala
+++ b/src/main/scala/NewRelic.scala
@@ -15,6 +15,7 @@ object NewRelic extends AutoPlugin {
     val newrelicAgent = taskKey[File]("New Relic agent jar location")
     val newrelicAppName = settingKey[String]("App Name reported to New Relic monitoring")
     val newrelicAttributesEnabled = settingKey[Boolean]("Enable sending of attributes to New Relic")
+    val newrelicBrowserInstrumentation = settingKey[Boolean]("Enable automatic Real User Monitoring")
     val newrelicConfig = taskKey[File]("Generates a New Relic configuration file")
     val newrelicConfigTemplate = settingKey[java.net.URL]("Location of New Relic configuration template")
     val newrelicLicenseKey = settingKey[Option[String]]("License Key for New Relic account")
@@ -35,6 +36,7 @@ object NewRelic extends AutoPlugin {
     newrelicAgent := findNewrelicAgent(update.value),
     newrelicAppName := name.value,
     newrelicAttributesEnabled := true,
+    newrelicBrowserInstrumentation := true,
     newrelicConfig := makeNewRelicConfig((target in Universal).value, newrelicConfigTemplate.value, newrelicTemplateReplacements.value),
     newrelicConfigTemplate := getNewrelicConfigTemplate,
     newrelicLicenseKey := None,
@@ -43,7 +45,8 @@ object NewRelic extends AutoPlugin {
       "app_name" -> newrelicAppName.value,
       "license_key" -> newrelicLicenseKey.value.getOrElse(""),
       "custom_tracing" -> newrelicCustomTracing.value.toString,
-      "attributes_enabled" -> newrelicAttributesEnabled.value.toString
+      "attributes_enabled" -> newrelicAttributesEnabled.value.toString,
+      "browser_monitoring" -> newrelicBrowserInstrumentation.value.toString
     ),
     newrelicIncludeApi := false,
     libraryDependencies += "com.newrelic.agent.java" % "newrelic-agent" % newrelicVersion.value % nrConfig,

--- a/src/sbt-test/sbt-newrelic/basic/test
+++ b/src/sbt-test/sbt-newrelic/basic/test
@@ -5,6 +5,7 @@ $ exec grep -q "addJava .*newrelic.jar" target/universal/stage/bin/app
 $ exec grep -q "app_name: app" target/universal/stage/newrelic/newrelic.yml
 $ exec grep -q "license_key: ''" target/universal/stage/newrelic/newrelic.yml
 $ exec grep -q "enable_custom_tracing: true" target/universal/stage/newrelic/newrelic.yml
+$ exec grep -q "auto_instrument: true" target/universal/stage/newrelic/newrelic.yml
 
 > set newrelicLicenseKey := Some("abc")
 > universal:stage


### PR DESCRIPTION
Playframework needs to be manually instrumented in order to work with New Relic's Browser monitoring. The auto_instrument flag in the browser_monitoring section must be set to false for this to work.

https://docs.newrelic.com/docs/agents/java-agent/instrumentation/page-load-timing-java