### PR TITLE
Add ability to disable akka_instrumentation from SBT configuration.

### DIFF
--- a/src/main/resources/com/gilt/sbt/newrelic/newrelic.yml.template
+++ b/src/main/resources/com/gilt/sbt/newrelic/newrelic.yml.template
@@ -244,10 +244,8 @@ common: &default_settings
     auto_instrument: true
 
   class_transformer:
-    # This instrumentation reports the name of the user principal returned from 
-    # HttpServletRequest.getUserPrincipal() when servlets and filters are invoked.
-    com.newrelic.instrumentation.servlet-user:
-      enabled: false
+    akka_instrumentation:
+      enabled: ${{akka_instrumentation_enabled}}
 
 # Application Environments
 # ------------------------------------------

--- a/src/main/scala/NewRelic.scala
+++ b/src/main/scala/NewRelic.scala
@@ -18,6 +18,7 @@ object NewRelic extends AutoPlugin {
     val newrelicConfig = taskKey[File]("Generates a New Relic configuration file")
     val newrelicConfigTemplate = settingKey[java.net.URL]("Location of New Relic configuration template")
     val newrelicLicenseKey = settingKey[Option[String]]("License Key for New Relic account")
+    val newrelicAkkaInstrumentation = settingKey[Boolean]("Specifies whether Akka instrumentation is enabled")
     val newrelicCustomTracing = settingKey[Boolean]("Option to scan and instrument @Trace annotations")
     val newrelicTemplateReplacements = settingKey[Seq[(String, String)]]("Replacements for New Relic configuration template")
     val newrelicIncludeApi = settingKey[Boolean]("Add New Relic API artifacts to library dependencies")
@@ -38,10 +39,12 @@ object NewRelic extends AutoPlugin {
     newrelicConfig := makeNewRelicConfig((target in Universal).value, newrelicConfigTemplate.value, newrelicTemplateReplacements.value),
     newrelicConfigTemplate := getNewrelicConfigTemplate,
     newrelicLicenseKey := None,
+    newrelicAkkaInstrumentation := true,
     newrelicCustomTracing := false,
     newrelicTemplateReplacements := Seq(
       "app_name" -> newrelicAppName.value,
       "license_key" -> newrelicLicenseKey.value.getOrElse(""),
+      "akka_instrumentation_enabled" -> newrelicAkkaInstrumentation.value.toString,
       "custom_tracing" -> newrelicCustomTracing.value.toString,
       "attributes_enabled" -> newrelicAttributesEnabled.value.toString
     ),


### PR DESCRIPTION
In some cases, Akka instrumentation may cause performance loss, so
users may wish to disable it.

This commit also removes another class_transformer entry - but the
value is removed in the upstream default template, and the default
value is the same as the one in the template anyway.