### PR TITLE
Bump NewRelic version to 3.22.0 (support for Play 2.4).

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Installation for sbt-native-packager 1.0.x (and Play 2.4.x)
 Add the following to your `project/plugins.sbt` file:
 
 ```scala
-addSbtPlugin("com.gilt.sbt" % "sbt-newrelic" % "0.1.2")
+addSbtPlugin("com.gilt.sbt" % "sbt-newrelic" % "0.1.3")
 ```
 
 To use the NewRelic settings in your project, add the `NewRelic` auto-plugin to your project.
@@ -62,7 +62,7 @@ Configuration
 To use a specific New Relic Java Agent version, add the following to your `build.sbt` file:
 
 ```scala
-newrelicVersion := "3.19.2"
+newrelicVersion := "3.22.0"
 ```
 
 To add a New Relic license key to the generated `newrelic.yml` file, add the following to your `build.sbt` file:

--- a/src/main/scala/NewRelic.scala
+++ b/src/main/scala/NewRelic.scala
@@ -33,7 +33,7 @@ object NewRelic extends AutoPlugin {
 
   override lazy val projectSettings = Seq(
     ivyConfigurations += nrConfig,
-    newrelicVersion := "3.19.2",
+    newrelicVersion := "3.22.0",
     newrelicAgent := findNewrelicAgent(update.value),
     newrelicAppName := name.value,
     newrelicAttributesEnabled := true,

--- a/src/sbt-test/sbt-newrelic/add-newrelic-api/test
+++ b/src/sbt-test/sbt-newrelic/add-newrelic-api/test
@@ -1,7 +1,7 @@
 > universal:stage
-$ absent target/universal/stage/lib/com.newrelic.agent.java.newrelic-api-3.19.2.jar
--$ exec grep -q newrelic-api-3.19.2.jar target/universal/stage/bin/app
+$ absent target/universal/stage/lib/com.newrelic.agent.java.newrelic-api-3.22.0.jar
+-$ exec grep -q newrelic-api-3.22.0.jar target/universal/stage/bin/app
 > set newrelicIncludeApi := true
 > universal:stage
-$ exists target/universal/stage/lib/com.newrelic.agent.java.newrelic-api-3.19.2.jar
-$ exec grep -q newrelic-api-3.19.2.jar target/universal/stage/bin/app
+$ exists target/universal/stage/lib/com.newrelic.agent.java.newrelic-api-3.22.0.jar
+$ exec grep -q newrelic-api-3.22.0.jar target/universal/stage/bin/app


### PR DESCRIPTION
See [Release Note](https://docs.newrelic.com/docs/release-notes/agent-release-notes/java-release-notes/java-agent-3220) and [discussion about Play 2.4](https://discuss.newrelic.com/t/metrics-not-shown-for-play-2-4/26637/36)