### PR TITLE
Bump NR version 3.26.1 -> 3.27.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Configuration
 To use a specific New Relic Java Agent version, add the following to your `build.sbt` file:
 
 ```scala
-newrelicVersion := "3.26.1"
+newrelicVersion := "3.27.0"
 ```
 
 To add a New Relic license key to the generated `newrelic.yml` file, add the following to your `build.sbt` file:

--- a/src/main/scala/NewRelic.scala
+++ b/src/main/scala/NewRelic.scala
@@ -33,7 +33,7 @@ object NewRelic extends AutoPlugin {
 
   override lazy val projectSettings = Seq(
     ivyConfigurations += nrConfig,
-    newrelicVersion := "3.26.1",
+    newrelicVersion := "3.27.0",
     newrelicAgent := findNewrelicAgent(update.value),
     newrelicAppName := name.value,
     newrelicAttributesEnabled := true,

--- a/src/sbt-test/sbt-newrelic/add-newrelic-api/test
+++ b/src/sbt-test/sbt-newrelic/add-newrelic-api/test
@@ -1,7 +1,7 @@
 > universal:stage
-$ absent target/universal/stage/lib/com.newrelic.agent.java.newrelic-api-3.26.1.jar
+$ absent target/universal/stage/lib/com.newrelic.agent.java.newrelic-api-3.27.0.jar
 -$ exec grep -q newrelic-api-3.27.0.jar target/universal/stage/bin/app
 > set newrelicIncludeApi := true
 > universal:stage
-$ exists target/universal/stage/lib/com.newrelic.agent.java.newrelic-api-3.26.1.jar
+$ exists target/universal/stage/lib/com.newrelic.agent.java.newrelic-api-3.27.0.jar
 $ exec grep -q newrelic-api-3.27.0.jar target/universal/stage/bin/app

--- a/src/sbt-test/sbt-newrelic/add-newrelic-api/test
+++ b/src/sbt-test/sbt-newrelic/add-newrelic-api/test
@@ -1,7 +1,7 @@
 > universal:stage
 $ absent target/universal/stage/lib/com.newrelic.agent.java.newrelic-api-3.26.1.jar
--$ exec grep -q newrelic-api-3.26.1.jar target/universal/stage/bin/app
+-$ exec grep -q newrelic-api-3.27.0.jar target/universal/stage/bin/app
 > set newrelicIncludeApi := true
 > universal:stage
 $ exists target/universal/stage/lib/com.newrelic.agent.java.newrelic-api-3.26.1.jar
-$ exec grep -q newrelic-api-3.26.1.jar target/universal/stage/bin/app
+$ exec grep -q newrelic-api-3.27.0.jar target/universal/stage/bin/app


### PR DESCRIPTION
New one just came out: https://docs.newrelic.com/docs/release-notes/agent-release-notes/java-release-notes/java-agent-3270