### PR TITLE
add support for native-packager generated bat scripts

### DIFF
--- a/src/main/scala/NewRelic.scala
+++ b/src/main/scala/NewRelic.scala
@@ -5,7 +5,7 @@ import sbt.Keys._
 
 import com.typesafe.sbt.SbtNativePackager._
 import com.typesafe.sbt.packager.archetypes.JavaAppPackaging
-import com.typesafe.sbt.packager.archetypes.JavaAppPackaging.autoImport.bashScriptExtraDefines
+import com.typesafe.sbt.packager.archetypes.JavaAppPackaging.autoImport._
 import com.typesafe.sbt.packager.archetypes.TemplateWriter
 
 object NewRelic extends AutoPlugin {
@@ -63,7 +63,8 @@ object NewRelic extends AutoPlugin {
       newrelicAgent.value -> "newrelic/newrelic.jar",
       newrelicConfig.value -> "newrelic/newrelic.yml"
     ),
-    bashScriptExtraDefines += """addJava "-javaagent:${app_home}/../newrelic/newrelic.jar""""
+    bashScriptExtraDefines += """addJava "-javaagent:${app_home}/../newrelic/newrelic.jar"""",
+    batScriptExtraDefines += """set "_JAVA_OPTS=%_JAVA_OPTS% -javaagent:%@@APP_ENV_NAME@@_HOME%\\newrelic\\newrelic.jar""""
   )
 
   private[newrelic] def makeNewRelicConfig(tmpDir: File, source: java.net.URL, replacements: Seq[(String, String)]): File = {

--- a/src/sbt-test/sbt-newrelic/basic/test
+++ b/src/sbt-test/sbt-newrelic/basic/test
@@ -2,6 +2,7 @@
 $ exists target/universal/stage/newrelic/newrelic.yml
 $ exists target/universal/stage/newrelic/newrelic.jar
 $ exec grep -q "addJava .*newrelic.jar" target/universal/stage/bin/app
+$ exec grep -q "javaagent:%APP_HOME%.*newrelic.jar" target/universal/stage/bin/app.bat
 $ exec grep -q "app_name: app" target/universal/stage/newrelic/newrelic.yml
 $ exec grep -q "license_key: ''" target/universal/stage/newrelic/newrelic.yml
 $ exec grep -q "enable_custom_tracing: true" target/universal/stage/newrelic/newrelic.yml


### PR DESCRIPTION
Wish we wouldn't require this (aka running windows nodes), but this loads the newrelic javaagent as seamless when using the bat scripts generated by the native packager.