### PR TITLE
Add ability to set ignore_errors list

### DIFF
--- a/src/main/resources/com/gilt/sbt/newrelic/newrelic.yml.template
+++ b/src/main/resources/com/gilt/sbt/newrelic/newrelic.yml.template
@@ -191,7 +191,7 @@ common: &default_settings
     # by providing a comma separated list of full class names.
     # The default is to exclude akka.actor.ActorKilledException. If you want to override
     # this, you must provide any new value as an empty list is ignored.
-    ignore_errors: akka.actor.ActorKilledException
+    ignore_errors: ${{ignore_errors}}
 
     # Use this property to exclude specific http status codes from being reported as errors
     # by providing a comma separated list of status codes.

--- a/src/main/scala/NewRelic.scala
+++ b/src/main/scala/NewRelic.scala
@@ -21,6 +21,7 @@ object NewRelic extends AutoPlugin {
     val newrelicLicenseKey = settingKey[Option[String]]("License Key for New Relic account")
     val newrelicAkkaInstrumentation = settingKey[Boolean]("Specifies whether Akka instrumentation is enabled")
     val newrelicCustomTracing = settingKey[Boolean]("Option to scan and instrument @Trace annotations")
+    val newrelicIgnoreErrors = settingKey[Seq[String]]("List of exceptions that New Relic should not report as errors")
     val newrelicTemplateReplacements = settingKey[Seq[(String, String)]]("Replacements for New Relic configuration template")
     val newrelicIncludeApi = settingKey[Boolean]("Add New Relic API artifacts to library dependencies")
   }
@@ -43,13 +44,15 @@ object NewRelic extends AutoPlugin {
     newrelicLicenseKey := None,
     newrelicAkkaInstrumentation := true,
     newrelicCustomTracing := false,
+    newrelicIgnoreErrors := Seq("akka.actor.ActorKilledException"),
     newrelicTemplateReplacements := Seq(
       "app_name" -> newrelicAppName.value,
       "license_key" -> newrelicLicenseKey.value.getOrElse(""),
       "akka_instrumentation_enabled" -> newrelicAkkaInstrumentation.value.toString,
       "custom_tracing" -> newrelicCustomTracing.value.toString,
       "attributes_enabled" -> newrelicAttributesEnabled.value.toString,
-      "browser_monitoring" -> newrelicBrowserInstrumentation.value.toString
+      "browser_monitoring" -> newrelicBrowserInstrumentation.value.toString,
+      "ignore_errors" -> newrelicIgnoreErrors.value.mkString(",")
     ),
     newrelicIncludeApi := false,
     libraryDependencies += "com.newrelic.agent.java" % "newrelic-agent" % newrelicVersion.value % nrConfig,

--- a/src/sbt-test/sbt-newrelic/basic/test
+++ b/src/sbt-test/sbt-newrelic/basic/test
@@ -7,6 +7,7 @@ $ exec grep -q "app_name: app" target/universal/stage/newrelic/newrelic.yml
 $ exec grep -q "license_key: ''" target/universal/stage/newrelic/newrelic.yml
 $ exec grep -q "enable_custom_tracing: true" target/universal/stage/newrelic/newrelic.yml
 $ exec grep -q "auto_instrument: true" target/universal/stage/newrelic/newrelic.yml
+$ exec grep -q "ignore_errors: akka.actor.ActorKilledException" target/universal/stage/newrelic/newrelic.yml
 
 > set newrelicLicenseKey := Some("abc")
 > universal:stage


### PR DESCRIPTION
We missed the ability to set `ignore_errors` in our projects.
We could just use our own newrelic.yml file but it feels a lot more handy to be able to set these things in sbt and not having to create a full config file to just change this little setting.

I don't know how many template replacements you wanna add before it just becomes a case of having all the settings in build.sbt instead of the yml file.

I had took a look at your tests and added a simple check that ignore_errors defaults to what it defaulted to before.