### PR TITLE
NewRelic agent 3.32.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Configuration
 To use a specific New Relic Java Agent version, add the following to your `build.sbt` file:
 
 ```scala
-newrelicVersion := "3.31.1"
+newrelicVersion := "3.32.0"
 ```
 
 To add a New Relic license key to the generated `newrelic.yml` file, add the following to your `build.sbt` file:

--- a/src/main/scala/NewRelic.scala
+++ b/src/main/scala/NewRelic.scala
@@ -34,7 +34,7 @@ object NewRelic extends AutoPlugin {
 
   override lazy val projectSettings = Seq(
     ivyConfigurations += nrConfig,
-    newrelicVersion := "3.31.1",
+    newrelicVersion := "3.32.0",
     newrelicAgent := findNewrelicAgent(update.value),
     newrelicAppName := name.value,
     newrelicAttributesEnabled := true,

--- a/src/sbt-test/sbt-newrelic/add-newrelic-api/test
+++ b/src/sbt-test/sbt-newrelic/add-newrelic-api/test
@@ -1,7 +1,7 @@
 > universal:stage
-$ absent target/universal/stage/lib/com.newrelic.agent.java.newrelic-api-3.31.1.jar
--$ exec grep -q newrelic-api-3.31.1.jar target/universal/stage/bin/app
+$ absent target/universal/stage/lib/com.newrelic.agent.java.newrelic-api-3.32.0.jar
+-$ exec grep -q newrelic-api-3.32.0.jar target/universal/stage/bin/app
 > set newrelicIncludeApi := true
 > universal:stage
-$ exists target/universal/stage/lib/com.newrelic.agent.java.newrelic-api-3.31.1.jar
-$ exec grep -q newrelic-api-3.31.1.jar target/universal/stage/bin/app
+$ exists target/universal/stage/lib/com.newrelic.agent.java.newrelic-api-3.32.0.jar
+$ exec grep -q newrelic-api-3.32.0.jar target/universal/stage/bin/app


### PR DESCRIPTION
## Newrelic java agent 3.32.0 is released.
Could you review this release as a default version?
* 3.31.2 has bug [incorrect response times in playframework 2.5.x](https://discuss.newrelic.com/t/play-framework-2-5-application-incorrectly-showing-very-high-response-times/39706). 
* 3.32.0 fixes [playframework 2.5.x issue](https://docs.newrelic.com/docs/release-notes/agent-release-notes/java-release-notes/java-agent-3320).

Thanks. :blush: